### PR TITLE
Allows for incrementing bundle versions if they have 1, 2, or 3 parts

### DIFF
--- a/SwiftAuthorizationHelperTool/Info.plist
+++ b/SwiftAuthorizationHelperTool/Info.plist
@@ -5,6 +5,6 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
Previously all bundle versions were assumed to have 3 numeric parts and any "missing" parts were considered 0. This resulted in the patch value always being incremented even if there originally was no patch value.