### PR TITLE
Ensure build scripts are compiled before execution for Xcode 15 compa…

### DIFF
--- a/BuildScripts/PropertyListModifier.swift
+++ b/BuildScripts/PropertyListModifier.swift
@@ -1,4 +1,3 @@
-#!/usr/bin/env xcrun --sdk macosx swift
 //
 //  PropertyListModifier.swift
 //  SwiftAuthorizationSample

--- a/SwiftAuthorizationSample.xcodeproj/project.pbxproj
+++ b/SwiftAuthorizationSample.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift satisfy-job-bless-requirements\n";
+			shellScript = "swiftc \"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift -o \"${SRCROOT}\"/BuildScripts/PropertyListModifier\n\"${SRCROOT}\"/BuildScripts/PropertyListModifier satisfy-job-bless-requirements\n";
 		};
 		99F409F0272303D10010500C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -327,7 +327,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift cleanup-job-bless-requirements\n";
+			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier cleanup-job-bless-requirements\nrm \"${SRCROOT}\"/BuildScripts/PropertyListModifier\n";
 		};
 		99F409F1272303E00010500C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -344,7 +344,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift satisfy-job-bless-requirements specify-mach-services auto-increment-version\n\n";
+			shellScript = "swiftc \"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift -o \"${SRCROOT}\"/BuildScripts/PropertyListModifier\n\"${SRCROOT}\"/BuildScripts/PropertyListModifier satisfy-job-bless-requirements specify-mach-services auto-increment-version\n";
 		};
 		99F409F2272303F20010500C /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -361,7 +361,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier.swift cleanup-job-bless-requirements cleanup-mach-services\n";
+			shellScript = "\"${SRCROOT}\"/BuildScripts/PropertyListModifier cleanup-job-bless-requirements cleanup-mach-services\nrm \"${SRCROOT}\"/BuildScripts/PropertyListModifier\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
...tibility.

This commit updates the build scripts to compile PropertyListModifier.swift into executable before running. This change addresses the issue(#17) introduced in Xcode 15, where running Swift scripts directly can lead to errors due to the updated execution environment handling, **which hasn't been solved by Apple yet**. By compiling Swift scripts first, we ensure compatibility with Xcode 15 and later versions, while also reducing potential environmental discrepancies.

There might be a slight increase in compilation time during the build phase, approximately by a few hundred milliseconds.